### PR TITLE
Add Dart frontend and Rust backend in monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # experiment
+
+This repository is organized as a simple monorepo with:
+
+- **frontend** – a Dart web application that presents a login page and, on successful authentication, displays a home page noting the project was created by AI.
+- **backend** – a Rust service using SQLite for persistence. It exposes a `/login` endpoint used by the frontend.
+
+## Running
+
+### Backend
+```bash
+cd backend
+cargo run
+```
+
+The server listens on `http://localhost:3000` and stores its data in `backend/data/app.db`.
+
+### Frontend
+The frontend requires the Dart SDK. After installing Dart, compile and serve:
+```bash
+cd frontend
+# build main.dart to JavaScript
+dart run build_runner build
+# then serve index.html with any static file server
+```
+
+The login page will send credentials to the backend and navigate to the home page on success.

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "backend"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+axum = "0.7"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio-rustls"] }
+anyhow = "1.0"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,0 +1,85 @@
+use axum::{
+    extract::State,
+    http::StatusCode,
+    routing::post,
+    Json, Router,
+};
+use serde::Deserialize;
+use sqlx::{sqlite::SqlitePoolOptions, Row, SqlitePool};
+use std::net::SocketAddr;
+use anyhow::Result;
+
+#[derive(Clone)]
+struct AppState {
+    pool: SqlitePool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect("sqlite:./data/app.db")
+        .await?;
+
+    init_db(&pool).await?;
+
+    let state = AppState { pool };
+
+    let app = Router::new().route("/login", post(login)).with_state(state);
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await?;
+
+    Ok(())
+}
+
+async fn init_db(pool: &SqlitePool) -> Result<()> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            password TEXT NOT NULL
+        );
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query("INSERT OR IGNORE INTO users (username, password) VALUES (?, ?)")
+        .bind("admin")
+        .bind("password")
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct LoginPayload {
+    username: String,
+    password: String,
+}
+
+async fn login(
+    State(state): State<AppState>,
+    Json(payload): Json<LoginPayload>,
+) -> StatusCode {
+    match sqlx::query("SELECT password FROM users WHERE username = ?")
+        .bind(&payload.username)
+        .fetch_optional(&state.pool)
+        .await
+    {
+        Ok(Some(row)) => {
+            let stored: String = row.get("password");
+            if stored == payload.password {
+                StatusCode::OK
+            } else {
+                StatusCode::UNAUTHORIZED
+            }
+        }
+        _ => StatusCode::UNAUTHORIZED,
+    }
+}

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -1,0 +1,10 @@
+name: frontend
+description: Simple Dart web frontend for login demonstration.
+version: 0.1.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+dependencies:
+  http: ^1.1.0
+dev_dependencies:
+  build_runner: ^2.4.0
+  build_web_compilers: ^4.0.0

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>AI Auth App</title>
+</head>
+<body>
+  <div id="content"></div>
+  <script defer src="main.dart.js"></script>
+</body>
+</html>

--- a/frontend/web/main.dart
+++ b/frontend/web/main.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'dart:html';
+
+void main() {
+  final content = querySelector('#content')!;
+  final form = FormElement();
+
+  final userInput = InputElement()..placeholder = 'Username';
+  final passInput = InputElement()
+    ..type = 'password'
+    ..placeholder = 'Password';
+  final submit = ButtonElement()..text = 'Login';
+
+  form.children.addAll([userInput, passInput, submit]);
+  content.children.add(form);
+
+  submit.onClick.listen((_) async {
+    final username = userInput.value ?? '';
+    final password = passInput.value ?? '';
+
+    try {
+      final response = await HttpRequest.request(
+        'http://localhost:3000/login',
+        method: 'POST',
+        requestHeaders: {'Content-Type': 'application/json'},
+        sendData: jsonEncode({'username': username, 'password': password}),
+      );
+
+      if (response.status == 200) {
+        content.text = 'This is an AI-created project.';
+      } else {
+        window.alert('Invalid credentials');
+      }
+    } catch (e) {
+      window.alert('Error contacting server');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold Dart web frontend with login page and simple home screen
- implement Rust Axum backend with SQLite and `/login` endpoint
- document monorepo structure and run instructions

## Testing
- `dart --version` *(fails: command not found)*
- `cd backend && cargo test` *(fails: failed to download crates - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a8acbdc2083239477743809ebcf01